### PR TITLE
No direct access to interpreter result

### DIFF
--- a/generic/dpCmds.c
+++ b/generic/dpCmds.c
@@ -242,7 +242,9 @@ Dp_CopyCmd(dummy, interp, argc, argv)
 	    goto error;
         }
         if (actuallyRead == 0) {
-            sprintf(interp->result, "%d", totalRead);
+            char result[32];
+            snprintf(result, 32, "%d", totalRead);
+            Tcl_SetResult(interp, result, TCL_VOLATILE);
 	    goto done;
         }
 	for (i=0; i<numOutChans; i++) {
@@ -263,7 +265,9 @@ done:
     if (outChans != NULL) {
 	ckfree((char*)outChans);
     }
-    sprintf(interp->result, "%d", totalRead);
+    char result[32];
+    snprintf(result, 32, "%d", totalRead);
+    Tcl_SetResult(interp, result, TCL_VOLATILE);
     return TCL_OK;
 
 error:

--- a/generic/dpFilters.c
+++ b/generic/dpFilters.c
@@ -1401,7 +1401,7 @@ typedef struct {
     }
 
     /* Reserve the space for the result. */
-    needed = strlen(interp->result);
+    needed = strlen(Tcl_GetStringResult(interp));
 
     if(needed > 0) {
         *outBuf = (char *)ckalloc(needed);
@@ -1410,7 +1410,7 @@ typedef struct {
             return ENOMEM;
         }
 	*outLength = needed;
-	memcpy(*outBuf, interp->result, needed);
+	memcpy(*outBuf, Tcl_GetStringResult(interp), needed);
     }
 
     if(mode == DP_FILTER_CLOSE) {

--- a/generic/dpRPC.c
+++ b/generic/dpRPC.c
@@ -538,7 +538,7 @@ DpProcessRPCMessage(interp, chan, id, token, message)
 		    ckfree(errMsg);
 		} else {
 		    if (DpSendRPCMessage(rcPtr->chan, TOK_RET, id,
-			     interp->result) != TCL_OK) {
+			     Tcl_GetStringResult(interp)) != TCL_OK) {
 		    	goto error;
 		    }
 		}


### PR DESCRIPTION
Access to `result` in structure `Tcl_Interp` is restricted in Tcl 8.6.